### PR TITLE
Fix partial trade aggregation accounting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1945,7 +1945,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function maxDrawdown(series) { if (!series || series.length===0) return 0; let peak=series[0].equity, maxDD=0; for (const p of series){ peak=Math.max(peak,p.equity); maxDD=Math.max(maxDD, peak-p.equity);} return maxDD; }
   function streaks(arr){ let wc=0,lc=0,wmax=0,lmax=0; for (const v of arr){ if(v>0){wc++;lc=0;wmax=Math.max(wmax,wc);} else if(v<0){lc++;wc=0;lmax=Math.max(lmax,lc);} else {wc=0;lc=0;} } return {wmax,lmax}; }
   function computeAdvancedStats() {
-    const trades = state.realizedEvents.map(e => e.pnl);
+    const trades = state.realizedEvents.filter(e => e && e.symbol).map(e => e.pnl);
     const n = trades.length;
     const total = state.realizedPL;
     const wins = trades.filter(v => v > 0);
@@ -2024,7 +2024,9 @@ document.addEventListener('DOMContentLoaded', () => {
   function recomputeKpisForSim() {
     if (!isSimAccountName(selectedAccount)) return;
     const day0 = new Date(); day0.setHours(0, 0, 0, 0);
-    const daily = state.realizedEvents.filter(e => e.t >= day0.getTime()).reduce((a, e) => a + (e.pnl || 0), 0);
+    const daily = state.realizedEvents
+      .filter(e => e.t >= day0.getTime())
+      .reduce((a, e) => a + (e.delta ?? e.pnl ?? 0), 0);
     const lastCashForThis = (state.lastCashBalanceAccount === selectedAccount) ? state.lastCashBalance : null;
     const base = (Number.isFinite(lastCashForThis) && lastCashForThis !== 0)
       ? lastCashForThis
@@ -2215,39 +2217,92 @@ document.addEventListener('DOMContentLoaded', () => {
 		// injecte un "lot hérité" au début de la fenêtre pour permettre une agrégation correcte.
 		try { ensureSeedForClose(symbol, side, qty); } catch (e) { /* silencieux */ }
 
-		let trades = aggregateFromFill(symbol, side, qty, price, ts);
-		if (Number.isFinite(commission) && commission !== 0 && trades.length) {
-			const totQty = trades.reduce((a, t) => a + t.qty, 0) || 1;
-			trades = trades.map(t => ({ ...t, pnl: t.pnl - commission * (t.qty / totQty) }));
-		}
+                const aggregation = aggregateFromFill(symbol, side, qty, price, ts);
+                const partials = aggregation.partials || [];
+                let trades = aggregation.trades || [];
 
-		for (const t of trades) {
-			const inRange = shouldIncludeTrade(t.closeTime);
+                for (const part of partials) {
+                        if (!shouldIncludeTrade(part.closeTime)) continue;
 
-			if (inRange) {
-				state.realizedPL += t.pnl;
+                        state.realizedPL += part.pnl;
 
-				if (!state.symbolPL.has(t.symbol)) state.symbolPL.set(t.symbol, 0);
-				state.symbolPL.set(t.symbol, state.symbolPL.get(t.symbol) + t.pnl);
+                        if (!state.symbolPL.has(part.symbol)) state.symbolPL.set(part.symbol, 0);
+                        state.symbolPL.set(part.symbol, state.symbolPL.get(part.symbol) + part.pnl);
 
-				if (t.pnl > 0) state.wins++; else if (t.pnl < 0) state.losses++;
+                        if (part.lotRef) {
+                                part.lotRef.countedPnl = (part.lotRef.countedPnl || 0) + part.pnl;
+                        }
 
-				state.equitySeries.push({ t: t.closeTime, equity: state.realizedPL });
-				state.realizedEvents.push({
-					pnl: t.pnl, t: t.closeTime, symbol: t.symbol, side: t.side, qty: t.qty,
-					entry: t.entry, exit: t.exit, openTime: t.openTime, closeTime: t.closeTime
-				});
+                        const { lotRef, ...eventPart } = part;
 
-				addTradeRowTrade(t);
-			}
-		}
+                        state.equitySeries.push({ t: eventPart.closeTime, equity: state.realizedPL });
+                        state.realizedEvents.push({
+                                pnl: eventPart.pnl,
+                                delta: eventPart.pnl,
+                                t: eventPart.closeTime,
+                                symbol: null,
+                                side: eventPart.side,
+                                qty: eventPart.qty,
+                                entry: null,
+                                exit: null,
+                                openTime: eventPart.openTime,
+                                closeTime: eventPart.closeTime,
+                                synthetic: true
+                        });
+                }
 
-		if (trades.length) {
-			const em = document.getElementById('emptyMsg'); if (em) em.style.display = 'none';
-			refreshCharts();
-			recomputeKpisForSim();
-			requestKpisNow();
-		}
+                for (const t of trades) {
+                        if (t && t.lotRef) {
+                                t.countedPnl = Number.isFinite(t.lotRef.countedPnl) ? t.lotRef.countedPnl : 0;
+                                delete t.lotRef;
+                        }
+                }
+
+                if (Number.isFinite(commission) && commission !== 0 && trades.length) {
+                        const totQty = trades.reduce((a, t) => a + t.qty, 0) || 1;
+                        trades = trades.map(t => ({
+                                ...t,
+                                pnl: t.pnl - commission * (t.qty / totQty)
+                        }));
+                }
+
+                for (const t of trades) {
+                        const inRange = shouldIncludeTrade(t.closeTime);
+
+                        if (inRange) {
+                                const delta = t.pnl - (t.countedPnl || 0);
+                                state.realizedPL += delta;
+
+                                if (!state.symbolPL.has(t.symbol)) state.symbolPL.set(t.symbol, 0);
+                                state.symbolPL.set(t.symbol, state.symbolPL.get(t.symbol) + delta);
+
+                                if (t.pnl > 0) state.wins++; else if (t.pnl < 0) state.losses++;
+
+                                state.equitySeries.push({ t: t.closeTime, equity: state.realizedPL });
+                                state.realizedEvents.push({
+                                        pnl: t.pnl,
+                                        delta,
+                                        t: t.closeTime,
+                                        symbol: t.symbol,
+                                        side: t.side,
+                                        qty: t.qty,
+                                        entry: t.entry,
+                                        exit: t.exit,
+                                        openTime: t.openTime,
+                                        closeTime: t.closeTime,
+                                        synthetic: false
+                                });
+
+                                addTradeRowTrade(t);
+                        }
+                }
+
+                if (partials.length || trades.length) {
+                        const em = document.getElementById('emptyMsg'); if (em) em.style.display = 'none';
+                        refreshCharts();
+                        recomputeKpisForSim();
+                        requestKpisNow();
+                }
 	}
 
   // Filet de sécurité : re-demande des fills récents via 303 → 304
@@ -2305,27 +2360,54 @@ document.addEventListener('DOMContentLoaded', () => {
   const getLots = (sym) => { if (!_openLots.has(sym)) _openLots.set(sym, []); return _openLots.get(sym); };
   function aggregateFromFill(symbol, side, qty, rawPrice, timeMs) {
     const trades = [];
-    if (!symbol || !side || !qty || !Number.isFinite(rawPrice)) return trades;
+    const partials = [];
+    if (!symbol || !side || !qty || !Number.isFinite(rawPrice)) return { trades, partials };
     const priceN = normalizePrice(symbol, rawPrice);
     const lots = getLots(symbol);
     let remaining = qty;
 
+    const finalizeLot = (lot) => {
+      const parts = Array.isArray(lot.partials) ? lot.partials : [];
+      const totalQty = parts.reduce((sum, p) => sum + (p.qty || 0), 0);
+      if (totalQty <= 0) return null;
+      const totalPnl = parts.reduce((sum, p) => sum + (p.pnl || 0), 0);
+      const weightedExit = parts.reduce((sum, p) => sum + (p.exitPriceN || 0) * (p.qty || 0), 0) / totalQty;
+      const closeTime = parts.reduce((latest, p) => Math.max(latest, p.closeTime || lot.time), lot.time);
+      return {
+        symbol,
+        side: lot.side,
+        qty: totalQty,
+        openTime: lot.time,
+        closeTime,
+        entry: lot.priceN,
+        exit: weightedExit,
+        pnl: totalPnl,
+        countedPnl: lot.countedPnl || 0,
+        lotRef: lot
+      };
+    };
+
     while (remaining > 0 && lots.length && lots[0].side !== side) {
       const lot = lots[0];
+      if (!Array.isArray(lot.partials)) lot.partials = [];
+      if (!Number.isFinite(lot.realizedPnl)) lot.realizedPnl = 0;
+      if (!Number.isFinite(lot.countedPnl)) lot.countedPnl = 0;
       const closed = Math.min(remaining, lot.qty);
       const pnlPoints = (priceN - lot.priceN) * lot.side * closed;
       const pnlCur = priceToCurrency(symbol, pnlPoints);
-      trades.push({
-        symbol, side: lot.side, qty: closed,
-        openTime: lot.time, closeTime: timeMs,
-        entry: lot.priceN, exit: priceN, pnl: pnlCur
-      });
+      lot.partials.push({ qty: closed, exitPriceN: priceN, closeTime: timeMs, pnl: pnlCur });
+      lot.realizedPnl += pnlCur;
+      partials.push({ symbol, side: lot.side, qty: closed, pnl: pnlCur, closeTime: timeMs, openTime: lot.time, lotRef: lot });
       lot.qty -= closed;
       remaining -= closed;
-      if (lot.qty <= 0) lots.shift();
+      if (lot.qty <= 0) {
+        lots.shift();
+        const aggregated = finalizeLot(lot);
+        if (aggregated) trades.push(aggregated);
+      }
     }
-    if (remaining > 0) lots.push({ side, qty: remaining, priceN, time: timeMs });
-    return trades;
+    if (remaining > 0) lots.push({ side, qty: remaining, priceN, time: timeMs, partials: [], realizedPnl: 0, countedPnl: 0 });
+    return { trades, partials };
   }
   function addTradeRowTrade(tr) {
     const trEl = document.createElement('tr');
@@ -2397,15 +2479,18 @@ document.addEventListener('DOMContentLoaded', () => {
 		// (ex: position long >0, fill SELL => incomingSide=-1 → pos.qty * incomingSide < 0)
 		if (pos.qty * incomingSide < 0) {
 			// Sème juste ce qu'il faut pour permettre la fermeture
-			lots.unshift({
-				side: -incomingSide,
-				qty: needed,
-				priceN: pos.avg,                // moyen courant (meilleure approximation dispo sans remonter +)
-				time: FILTER_FROM_MS - 1,       // horodatage juste avant la fenêtre
-				inherited: true
-			});
-		}
-	}
+                        lots.unshift({
+                                side: -incomingSide,
+                                qty: needed,
+                                priceN: pos.avg,                // moyen courant (meilleure approximation dispo sans remonter +)
+                                time: FILTER_FROM_MS - 1,       // horodatage juste avant la fenêtre
+                                inherited: true,
+                                partials: [],
+                                realizedPnl: 0,
+                                countedPnl: 0
+                        });
+                }
+        }
 
   // === SÉLECTION COMPTE
   function pickAccount(acc) {
@@ -2819,7 +2904,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // Utilise la même pipeline que le live (dédup incluse)
         const beforeEvents = state.realizedEvents.length;
         applyFill(symbol, side, qty, price, ts, comm);
-        tradesCount += Math.max(0, state.realizedEvents.length - beforeEvents);
+        const newEvents = state.realizedEvents.slice(beforeEvents);
+        tradesCount += newEvents.filter(ev => ev && ev.symbol).length;
 
         state.fills.push(f);
       }


### PR DESCRIPTION
## Summary
- update live fill aggregation so partial exits bump realized PnL immediately while final trades subtract only the remaining delta and commissions
- keep per-lot counted/realized PnL state (including seeded lots) so aggregated trades and commissions reconcile correctly
- ignore synthetic partial events in analytics/daily KPIs and count only true trades when processing historical fills

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daccd9d910832685abd9e477d84f1b